### PR TITLE
fix(error-handling): disconnect signals before connecting 

### DIFF
--- a/src/controller/command-handlers/certificatereader.cpp
+++ b/src/controller/command-handlers/certificatereader.cpp
@@ -89,6 +89,7 @@ void CertificateReader::run(CardInfo::ptr _cardInfo)
 
 void CertificateReader::connectSignals(const WebEidUI* window)
 {
+    window->disconnect(this);
     connect(this, &CertificateReader::certificateReady, window, &WebEidUI::onCertificateReady);
 }
 


### PR DESCRIPTION
Disconnect signals before connecting in command handler base class `CertificateReader::connectSignals()`.

Refs WE2-115