### PR TITLE
std::vector does not contain null char at end and fix log output

### DIFF
--- a/src/controller/threads/readermonitorthread.hpp
+++ b/src/controller/threads/readermonitorthread.hpp
@@ -73,7 +73,7 @@ private:
 
     const std::string& commandType() const override
     {
-        static const std::string cmdType {CommandType::INSERT_CARD};
+        static const std::string cmdType = CommandType(CommandType::INSERT_CARD);
         return cmdType;
     }
 };


### PR DESCRIPTION
WE2-340

Signed-off-by: Raul Metsma <raul@metsma.ee>