### PR TITLE
refactor(RetriableError): remove ScardError from AutoSelectFailed and handle it directly in CATCH_PCSC_CPP_RETRIABLE_ERRORS

### DIFF
--- a/src/controller/controller.cpp
+++ b/src/controller/controller.cpp
@@ -165,7 +165,8 @@ void Controller::onCardsAvailable(const std::vector<electronic_id::CardInfo::ptr
         for (const auto& card : availableCards) {
             const auto protocol =
                 card->eid().smartcard().protocol() == SmartCard::Protocol::T0 ? "T=0" : "T=1";
-            qInfo() << "Using smart card protocol" << protocol << "for card" << card->eid().name();
+            qInfo() << "Card" << card->eid().name() << "in reader" << card->reader().name
+                    << "using protocol" << protocol;
         }
 
         window->showWaitingForCardPage(commandHandler->commandType());

--- a/src/controller/retriableerror.cpp
+++ b/src/controller/retriableerror.cpp
@@ -35,8 +35,6 @@ RetriableError toRetriableError(const electronic_id::AutoSelectFailed::Reason re
     using Reason = electronic_id::AutoSelectFailed::Reason;
 
     switch (reason) {
-    case Reason::SCARD_ERROR:
-        return RetriableError::SCARD_ERROR;
     case Reason::SERVICE_NOT_RUNNING:
         return RetriableError::SMART_CARD_SERVICE_IS_NOT_RUNNING;
     case Reason::NO_READERS:

--- a/src/controller/retriableerror.hpp
+++ b/src/controller/retriableerror.hpp
@@ -36,6 +36,7 @@ enum class RetriableError {
     FAILED_TO_COMMUNICATE_WITH_CARD_OR_READER,
     SMART_CARD_WAS_REMOVED,
     SMART_CARD_TRANSACTION_FAILED,
+    SCARD_ERROR,
     // libelectronic-id
     SMART_CARD_CHANGE_REQUIRED,
     SMART_CARD_COMMAND_ERROR,
@@ -43,7 +44,6 @@ enum class RetriableError {
     PKCS11_TOKEN_REMOVED,
     PKCS11_ERROR,
     // AutoSelectFailed::Reason
-    SCARD_ERROR,
     UNSUPPORTED_CARD,
     // CertificateReader::run
     NO_VALID_CERTIFICATE_AVAILABLE,
@@ -83,7 +83,8 @@ RetriableError toRetriableError(const electronic_id::AutoSelectFailed::Reason re
     catch (const pcsc_cpp::ScardTransactionFailedError& error)                                     \
     {                                                                                              \
         ERROR_HANDLER(RetriableError::SMART_CARD_TRANSACTION_FAILED, error);                       \
-    }
+    }                                                                                              \
+    catch (const pcsc_cpp::ScardError& error) { ERROR_HANDLER(RetriableError::SCARD_ERROR, error); }
 
 #define CATCH_LIBELECTRONIC_ID_RETRIABLE_ERRORS(ERROR_HANDLER)                                     \
     catch (const electronic_id::SmartCardChangeRequiredError& error)                               \


### PR DESCRIPTION
Refs WE2-472

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>