### PR TITLE
Revert "Add missing entitlements keys and include provisionprofile"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 set(FIREFOX_UUID "{e68418bc-f2b0-4459-a9ea-3e72b6751b07}" CACHE STRING "Firefox Extension UUID")
 set(FIREFOX_URL "https://addons.mozilla.org/firefox/downloads/latest/web-eid-webextension/latest.xpi" CACHE STRING "Mozilla AMO URL")
 
-set(SIGNCERT "" CACHE STRING "Common name of certificate to used sign binaries, empty skips signing  (Windows/macOS)")
-set(CROSSSIGNCERT "" CACHE STRING "Common name of certificate to used cross sign binaries, empty skips signing (Windows)")
-set(SAFARI_PROVISIONPROFILE "" CACHE STRING "Provision profile to include in application (macOS)")
+set(SIGNCERT "" CACHE STRING "Common name of certificate to used sign binaries, empty skip signing")
+set(CROSSSIGNCERT "" CACHE STRING "Common name of certificate to used cross sign binaries, empty skip signing")
 
 find_package(Qt5 COMPONENTS Core Widgets Network Test LinguistTools Svg REQUIRED)
 

--- a/src/mac/CMakeLists.txt
+++ b/src/mac/CMakeLists.txt
@@ -74,11 +74,6 @@ if(SIGNCERT)
             --entitlements ${CMAKE_CURRENT_LIST_DIR}/web-eid-safari-extension.entitlements
             $<TARGET_BUNDLE_DIR:web-eid-safari-extension>
     )
-    if(SAFARI_PROVISIONPROFILE)
-        add_custom_command(TARGET macdeployqt-safari POST_BUILD
-            COMMAND cp -a ${SAFARI_PROVISIONPROFILE} $<TARGET_BUNDLE_CONTENT_DIR:web-eid-safari>/embedded.provisionprofile
-        )
-    endif()
     add_custom_command(TARGET macdeployqt-safari POST_BUILD
         COMMAND codesign -f -s "Apple Distribution: ${SIGNCERT}"
             $<TARGET_BUNDLE_CONTENT_DIR:web-eid-safari>/Frameworks/*.*

--- a/src/mac/web-eid-safari.entitlements
+++ b/src/mac/web-eid-safari.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.application-identifier</key>
-	<string>ET847QJV9F.eu.web-eid.web-eid-safari</string>
-	<key>com.apple.developer.team-identifier</key>
-	<string>ET847QJV9F</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>


### PR DESCRIPTION
This reverts commit f342c4026cd429164ddc4efc8c4537842d8366a1.

Signed-off-by: Raul Metsma <raul@metsma.ee>