### PR TITLE
Remove deprecated key in desktop entry

### DIFF
--- a/install/web-eid.desktop
+++ b/install/web-eid.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Type=Application
 
 Exec=web-eid %F


### PR DESCRIPTION
The Encoding key is deprecated.

Ref: https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html

```sh
$ cat /usr/share/applications/web-eid.desktop
[Desktop Entry]
Encoding=UTF-8
Type=Application

Exec=web-eid %F
Icon=web-eid

Name=Web eID

Categories=Qt;Office;
$ desktop-file-validate /usr/share/applications/web-eid.desktop
/usr/share/applications/web-eid.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
```