### PR TITLE
Linux, BSD: Add BUNDLE_XPI option

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,6 @@
 #!/usr/bin/make -f
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk
+DEB_CMAKE_EXTRA_FLAGS = \
+	-DBUNDLE_XPI=ON
 DEB_MAKE_CHECK_TARGET = test

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -162,8 +162,11 @@ elseif(APPLE)
         )
     endif()
 else()
+    option(BUNDLE_XPI "Download and bundle the Firefox extension" OFF)
     include(GNUInstallDirs)
-    file(DOWNLOAD ${FIREFOX_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FIREFOX_UUID}.xpi)
+    if (BUNDLE_XPI)
+      file(DOWNLOAD ${FIREFOX_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FIREFOX_UUID}.xpi)
+    endif()
     set(WEBEID_PATH ${CMAKE_INSTALL_FULL_BINDIR}/web-eid)
     install(TARGETS web-eid DESTINATION ${CMAKE_INSTALL_BINDIR})
     if(EXISTS "/etc/debian_version")
@@ -179,8 +182,10 @@ else()
         DESTINATION ${CMAKE_INSTALL_DATADIR}/google-chrome/extensions)
     install(FILES ${CMAKE_SOURCE_DIR}/install/web-eid.desktop
         DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${FIREFOX_UUID}.xpi
-            DESTINATION ${CMAKE_INSTALL_DATADIR}/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384})
+    if (BUNDLE_XPI)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${FIREFOX_UUID}.xpi
+              DESTINATION ${CMAKE_INSTALL_DATADIR}/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384})
+    endif()
     foreach(RES 16 32 128 256 512)
         install(
             FILES ${CMAKE_SOURCE_DIR}/install/appicon_${RES}.png


### PR DESCRIPTION
The official Debian package includes this file, but other systems do not
neccessarily need it;  at least OpenBSD is unable to download files from
the intenet during packaging, so this fails ether way.

Allow for `-DBUNDLE_XPI=OFF` to skip it.`
