### PR TITLE
Use Qt 6.5 styleHint colorScheme to detect dark theme

### DIFF
--- a/src/controller/application.cpp
+++ b/src/controller/application.cpp
@@ -33,6 +33,7 @@
 #include <QPalette>
 #include <QProcess>
 #include <QSettings>
+#include <QStyleHints>
 #include <QTranslator>
 
 inline CommandWithArguments::second_type parseArgumentJson(const QString& argumentStr)
@@ -74,19 +75,17 @@ Application::Application(int& argc, char** argv, const QString& name) :
 #endif
 }
 
-#ifndef Q_OS_MAC
 bool Application::isDarkTheme()
 {
-#ifdef Q_OS_WIN
-    QSettings settings(
-        "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-        QSettings::NativeFormat);
-    return settings.value("AppsUseLightTheme", 1).toInt() == 0;
-#else
-    // There is currently no straightforward way to detect dark mode in Linux, but this works for supported OS-s.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    return styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+#elif defined(Q_OS_UNIX)
+    // There is currently no straightforward way to detect dark mode in Linux, but this works for
+    // supported OS-s.
     static const bool isDarkTheme = [] {
         QProcess p;
-        p.start(QStringLiteral("gsettings"), {"get", "org.gnome.desktop.interface", "color-scheme"});
+        p.start(QStringLiteral("gsettings"),
+                {"get", "org.gnome.desktop.interface", "color-scheme"});
         if (p.waitForFinished()) {
             return p.readAllStandardOutput().contains("dark");
         }
@@ -97,7 +96,6 @@ bool Application::isDarkTheme()
     return isDarkTheme;
 #endif
 }
-#endif
 
 void Application::loadTranslations(const QString& lang)
 {

--- a/src/controller/application.mm
+++ b/src/controller/application.mm
@@ -27,13 +27,6 @@
 #import <AppKit/AppKit.h>
 #import <Cocoa/Cocoa.h>
 
-bool Application::isDarkTheme()
-{
-    auto appearance = [NSApp.effectiveAppearance bestMatchFromAppearancesWithNames:
-        @[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
-    return [appearance isEqualToString:NSAppearanceNameDarkAqua];
-}
-
 void Application::showAbout()
 {
     NSLog(@"web-eid-app: starting app");

--- a/src/controller/threads/commandhandlerconfirmthread.hpp
+++ b/src/controller/threads/commandhandlerconfirmthread.hpp
@@ -31,9 +31,8 @@ class CommandHandlerConfirmThread : public ControllerChildThread
 public:
     CommandHandlerConfirmThread(QObject* parent, CommandHandler& handler, WebEidUI* w,
                                 const CardCertificateAndPinInfo& cardCertAndPin) :
-        ControllerChildThread(parent),
-        commandHandler(handler), cmdType(commandHandler.commandType()), window(w),
-        cardCertAndPinInfo(cardCertAndPin)
+        ControllerChildThread(parent), commandHandler(handler),
+        cmdType(commandHandler.commandType()), window(w), cardCertAndPinInfo(cardCertAndPin)
     {
     }
 

--- a/src/controller/threads/commandhandlerrunthread.hpp
+++ b/src/controller/threads/commandhandlerrunthread.hpp
@@ -31,8 +31,8 @@ class CommandHandlerRunThread : public ControllerChildThread
 public:
     CommandHandlerRunThread(QObject* parent, CommandHandler& handler,
                             const std::vector<electronic_id::CardInfo::ptr>& cs) :
-        ControllerChildThread(parent),
-        commandHandler(handler), cmdType(commandHandler.commandType()), cards(cs)
+        ControllerChildThread(parent), commandHandler(handler),
+        cmdType(commandHandler.commandType()), cards(cs)
     {
         // Connect retry signal to retry signal to pass it up from the command handler.
         connect(&commandHandler, &CommandHandler::retry, this, &ControllerChildThread::retry);

--- a/src/ui/certificatewidget.cpp
+++ b/src/ui/certificatewidget.cpp
@@ -142,8 +142,7 @@ void CertificateWidget::paintEvent(QPaintEvent* /*event*/)
 
 CertificateButton::CertificateButton(const CardCertificateAndPinInfo& cardCertPinInfo,
                                      QWidget* parent) :
-    QAbstractButton(parent),
-    CertificateWidgetInfo(this)
+    QAbstractButton(parent), CertificateWidgetInfo(this)
 {
     setCheckable(true);
     setAutoExclusive(true);

--- a/src/ui/webeiddialog.cpp
+++ b/src/ui/webeiddialog.cpp
@@ -653,8 +653,7 @@ void WebEidDialog::setupOK(Func&& func, const std::function<QString()>& text, bo
     connect(ui->okButton, &QPushButton::clicked, this, std::forward<Func>(func));
     ui->okButton->show();
     ui->okButton->setEnabled(enabled);
-    setTrText(
-        ui->okButton, text ? text : [] { return tr("Confirm"); });
+    setTrText(ui->okButton, text ? text : [] { return tr("Confirm"); });
     ui->cancelButton->show();
     ui->cancelButton->setEnabled(true);
     ui->helpButton->hide();


### PR DESCRIPTION
- keep linux compatibility

WE2-826

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
