### PR TITLE
Do not include exception message in JSON error result

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           vcpkgArguments: gtest openssl
           vcpkgTriplet: x64-windows
-          vcpkgGitCommitId: 9b9c2758ece1d8ac0de90589730bb5ccf45c0874
+          vcpkgGitCommitId: 98a562a04cd03728f399e79e1b37bcccb5a69b37
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/src/controller/command-handlers/authenticate.cpp
+++ b/src/controller/command-handlers/authenticate.cpp
@@ -145,7 +145,8 @@ QVariantMap Authenticate::onConfirm(WebEidUI* window,
             emit verifyPinFailed(failure.status(), failure.retries());
         }
         if (failure.retries() > 0) {
-            throw CommandHandlerVerifyPinFailed(failure.what());
+            // Hide error message as it may contain APDU code
+            throw CommandHandlerVerifyPinFailed("Verifying PIN failed");
         }
         throw;
     }

--- a/src/controller/command-handlers/sign.cpp
+++ b/src/controller/command-handlers/sign.cpp
@@ -122,7 +122,8 @@ QVariantMap Sign::onConfirm(WebEidUI* window, const CardCertificateAndPinInfo& c
         // Retries > 0 means that there are retries remaining,
         // < 0 means that retry count is unknown, == 0 means that the PIN is blocked.
         if (failure.retries() != 0) {
-            throw CommandHandlerVerifyPinFailed(failure.what());
+            // Hide error message as it may contain APDU code
+            throw CommandHandlerVerifyPinFailed("Verifying PIN failed");
         }
         throw;
     }

--- a/src/controller/controller.cpp
+++ b/src/controller/controller.cpp
@@ -103,6 +103,13 @@ void Controller::run()
 
         startCommandExecution();
 
+    // We catch all exceptions that expose APDU code separately to ensure that it is not leaked
+    } catch (const electronic_id::VerifyPinFailed&) {
+        onCriticalFailure("Technical error in verifying PIN");
+    } catch (const electronic_id::SmartCardError&) {
+        onCriticalFailure("Technical error communicating with Smart card");
+    } catch (const pcsc_cpp::Error&) {
+        onCriticalFailure("Technical error communicating with ID card");
     } catch (const std::exception& error) {
         onCriticalFailure(error.what());
     }
@@ -161,6 +168,7 @@ void Controller::connectOkCancelWaitingForPinPad()
 
     connect(window, &WebEidUI::accepted, this, &Controller::onDialogOK);
     connect(window, &WebEidUI::rejected, this, &Controller::onDialogCancel);
+    /* Only safe error messages are emitted here */
     connect(window, &WebEidUI::failure, this, &Controller::onCriticalFailure);
     connect(window, &WebEidUI::waitingForPinPad, this, &Controller::onConfirmCommandHandler);
 }
@@ -185,6 +193,13 @@ void Controller::onCardsAvailable(const std::vector<electronic_id::CardInfo::ptr
 
         runCommandHandler(availableCards);
 
+    // We catch all exceptions that expose APDU code separately to ensure that it is not leaked
+    } catch (const electronic_id::VerifyPinFailed&) {
+        onCriticalFailure("Technical error in verifying PIN");
+    } catch (const electronic_id::SmartCardError&) {
+        onCriticalFailure("Technical error communicating with Smart card");
+    } catch (const pcsc_cpp::Error&) {
+        onCriticalFailure("Technical error communicating with ID card");
     } catch (const std::exception& error) {
         onCriticalFailure(error.what());
     }
@@ -207,6 +222,13 @@ void Controller::runCommandHandler(const std::vector<electronic_id::CardInfo::pt
 
         commandHandlerRunThread->start();
 
+    // We catch all exceptions that expose APDU code separately to ensure that it is not leaked
+    } catch (const electronic_id::VerifyPinFailed&) {
+        onCriticalFailure("Technical error in verifying PIN");
+    } catch (const electronic_id::SmartCardError&) {
+        onCriticalFailure("Technical error communicating with Smart card");
+    } catch (const pcsc_cpp::Error&) {
+        onCriticalFailure("Technical error communicating with ID card");
     } catch (const std::exception& error) {
         onCriticalFailure(error.what());
     }
@@ -263,6 +285,13 @@ void Controller::onConfirmCommandHandler(const CardCertificateAndPinInfo& cardCe
 
         commandHandlerConfirmThread->start();
 
+    // We catch all exceptions that expose APDU code separately to ensure that it is not leaked
+    } catch (const electronic_id::VerifyPinFailed&) {
+        onCriticalFailure("Technical error in verifying PIN");
+    } catch (const electronic_id::SmartCardError&) {
+        onCriticalFailure("Technical error communicating with Smart card");
+    } catch (const pcsc_cpp::Error&) {
+        onCriticalFailure("Technical error communicating with ID card");
     } catch (const std::exception& error) {
         onCriticalFailure(error.what());
     }
@@ -301,6 +330,13 @@ void Controller::onRetry()
 
         startCommandExecution();
 
+    // We catch all exceptions that expose APDU code separately to ensure that it is not leaked
+    } catch (const electronic_id::VerifyPinFailed&) {
+        onCriticalFailure("Technical error in verifying PIN");
+    } catch (const electronic_id::SmartCardError&) {
+        onCriticalFailure("Technical error communicating with Smart card");
+    } catch (const pcsc_cpp::Error&) {
+        onCriticalFailure("Technical error communicating with ID card");
     } catch (const std::exception& error) {
         onCriticalFailure(error.what());
     }
@@ -350,11 +386,11 @@ void Controller::onPinPadCancel()
     window->quit();
 }
 
-void Controller::onCriticalFailure(const QString& error)
+void Controller::onCriticalFailure(const QString& msg)
 {
     qCritical() << "Exiting due to command" << std::string(commandType())
-                << "fatal error:" << error;
-    _result = makeErrorObject(RESP_TECH_ERROR, error);
+                << "fatal error:" << msg;
+    _result = makeErrorObject(RESP_TECH_ERROR, msg);
     writeResponseToStdOut(isInStdinMode, _result, commandType());
     disposeUI();
     WebEidUI::showFatalError();

--- a/src/controller/threads/controllerchildthread.hpp
+++ b/src/controller/threads/controllerchildthread.hpp
@@ -71,11 +71,13 @@ public:
                 break;
             default:
                 qCritical() << "Command" << commandType() << "fatal error:" << error;
-                emit failure(error.what());
+                // Hide error message as it may contain APDU code
+                emit failure("Technical error in verifying PIN");
             }
-        }
-        catch (const std::exception& error)
-        {
+        } catch (const pcsc_cpp::Error&) {
+            // Hide error message as it may contain APDU code
+            emit failure("Technical error communicating with ID card");
+        } catch (const std::exception& error) {
             qCritical() << "Command" << commandType() << "fatal error:" << error;
             emit failure(error.what());
         }


### PR DESCRIPTION
We2 556

Certain libpcsc exceptions contain actual transmitted or expected APDU in message. Passing these to webextension creates a potential risk of leaking sensitive data.

Signed-off-by: Lauris Kaplinski <lauris@raulwalter.com>
